### PR TITLE
feat: lumberjack-parity rotating-file options (stable name, age, compress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `RotatingFileHandler` options for lumberjack parity — all opt-in and OFF by default, so a
+  zero-option handler stays byte-identical to the previous one:
+  - `WithStableCurrentName()` keeps the live file at a fixed `prefix.log` path (rotated
+    backups stay indexed `prefix.<8 hex>.log`) so external tooling can follow it with
+    `tail -F`. Resume seeds size from `prefix.log` and adopts legacy indexed files as
+    backups.
+  - `WithMaxAge(d)` prunes rotated backups older than `d` (by mtime) on rotation, on top of
+    the `WithMaxFiles` count bound; `d <= 0` disables it. The unit is a `time.Duration`, so
+    pass the full span — `WithMaxAge(14 * 24 * time.Hour)`, not `WithMaxAge(14)`.
+  - `WithCompress()` gzips each rotated backup to `prefix.<8 hex>.log.gz` and removes the
+    plaintext, synchronously under the handler mutex and crash-safely (temp file + fsync +
+    rename, then remove), preserving the source mtime so age pruning stays honest. A
+    crash-interrupted compression self-heals on the next construction (the `.gz` wins).
+- `NewFileLogger` gains `WithMaxFileAge(d)` and `WithFileCompression()`, forwarding the two
+  options above to the underlying rotating handler. `WithStableCurrentName` is intentionally
+  not forwarded — `NewFileLogger` timestamps every file line, which is at odds with a stable
+  tail-able access-log format.
+
 ## [1.0.7] - 2026-07-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-20
+
 ### Added
 
 - `RotatingFileHandler` options for lumberjack parity — all opt-in and OFF by default, so a
@@ -25,6 +27,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   options above to the underlying rotating handler. `WithStableCurrentName` is intentionally
   not forwarded — `NewFileLogger` timestamps every file line, which is at odds with a stable
   tail-able access-log format.
+
+### Fixed
+
+- `FileByFormatHandler` now surfaces its file-close error on the `Write` return instead of
+  silently discarding it: the per-write closure had unnamed returns, so a deferred close that
+  assigned into `err` was dropped after the return value was copied.
 
 ## [1.0.7] - 2026-07-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Test Commands
 
-**No Makefile** — use raw `go`. Package is pure Go: build/test with `CGO_ENABLED=0`, tests always `-race` (append `-run <name>` for a single test/subtest):
+**No Makefile** — use raw `go`. The package builds clean with `CGO_ENABLED=0` (pure Go, no cgo deps), but the race detector needs cgo on this arm64 host, so race tests run with `CGO_ENABLED=1` (append `-run <name>` for a single test/subtest):
 
 ```bash
-CGO_ENABLED=0 go test -race ./...    # full suite
+CGO_ENABLED=1 go test -race ./...    # full suite (race needs cgo on this arm64 host)
+CGO_ENABLED=0 go test ./...          # no-cgo build proof
 go vet ./... && gofmt -l .           # vet + list unformatted
 ```
 
@@ -54,9 +55,10 @@ Convenience writers: `Printf`/`Print`, `Write` (`io.Writer` at `minimumLogLevel`
 
 ### LogLevel is consumer-defined
 
-`LogLevel` is just `type LogLevel int`. **The library ships no DEBUG/INFO/WARN/ERROR
-constants** — the consumer declares their own (see README usage). Severity ordering is
-by integer value: higher = more severe, since the gate is `level < minimumLogLevel`.
+`LogLevel` is just `type LogLevel int`. **The root package ships no DEBUG/INFO/WARN/ERROR
+constants** — the consumer declares their own, or imports the `levels` subpackage
+(`Debug`..`Critical` = 1..6, plus `Parse`/`Name`). Severity ordering is by integer value:
+higher = more severe, since the gate is `level < minimumLogLevel`.
 
 ### Plugging the logger into other writers
 
@@ -64,7 +66,7 @@ by integer value: higher = more severe, since the gate is `level < minimumLogLev
 
 ### Handlers (`handler.go`)
 
-Every handler is a **factory function returning `io.Writer`**, internally wrapping a mutex-guarded `writer` so each handler serializes its own writes. `PrintHandler()` is the default when `NewLogger` gets no handlers. File handlers (`CyclicOverwritingFilesHandler`, `FileByFormatHandler`) share `.log` extension, `0640` perms, append mode, and oldest-first pruning past their max-files bound; runtime logs live under `./logs/`.
+Every handler is a **factory function returning `io.Writer`**, internally wrapping a mutex-guarded `writer` so each handler serializes its own writes. `TimestampedPrintHandler()` is the default when `NewLogger` gets no handlers. File handlers (`RotatingFileHandler`, `FileByFormatHandler`) share `.log` extension, `0640` perms, append mode, and oldest-first pruning past their max-files bound; runtime logs live under `./logs/`. `RotatingFileHandler` carries opt-in `RotatingFileOption`s — `WithStableCurrentName` (fixed `prefix.log` live path for `tail -F`), `WithMaxAge` (mtime retention), `WithCompress` (gzip backups) — all off by default and byte-identical when unused.
 
 ### HTTP traffic tap (`httptap/`)
 
@@ -85,7 +87,8 @@ Generic Go conventions (style, file declaration order, test structure, test-only
 code placement, godoc, error discipline, code organization) come from the
 `stack-go` plugin skills — they are not restated here. Project-specific constraints:
 
-- **No CGO**: keep `CGO_ENABLED=0` for build/test. The only direct deps are
+- **No CGO**: keep the package cgo-free (`CGO_ENABLED=0` builds clean); the `-race`
+  gate is the exception — it needs cgo (see Build & Test). The only direct deps are
   `stretchr/testify` (tests) and `twinj/uuid` (hook IDs) — avoid adding heavy or
   CGO-dependent dependencies.
 - **Race coverage is load-bearing**: concurrency-sensitive handlers have dedicated
@@ -95,7 +98,7 @@ code placement, godoc, error discipline, code organization) come from the
   `TestFileByFormatHandlerV2`) predate the one-`Test*`-per-method rule; prefer the
   canonical subtest form for new and refactored tests, don't mass-rename.
 - **No Makefile**: gates run as raw Go commands (`gofmt -l .`, `go vet ./...`,
-  `CGO_ENABLED=0 go test -race ./...`).
+  `CGO_ENABLED=1 go test -race ./...` — race needs cgo on this arm64 host).
 
 ## Working agreement
 
@@ -109,7 +112,7 @@ All non-trivial work follows the plan-first pipeline:
    C: performance & architecture) and the changed files. Full three-lens fan-out is
    mandatory on the first review; the post-fix re-review is ONE solo reviewer scoped
    to the changed lines.
-4. **Gate** — `gofmt -l .` clean, `go vet` and `CGO_ENABLED=0 go test -race ./...`
+4. **Gate** — `gofmt -l .` clean, `go vet` and `CGO_ENABLED=1 go test -race ./...`
    green before review; a red tree goes to the `testdoctor` agent first.
 5. **Complete** — the orchestrator merges the three reports, deduplicates, resolves
    conflicting verdicts (naming what was rejected and why; the user has final say).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ option — is on [pkg.go.dev](https://pkg.go.dev/github.com/prorochestvo/loginje
 - **`httptap` redaction is always on:** `Authorization`, `Proxy-Authorization`, `Cookie`,
   and `Set-Cookie` are never logged. `NewRecoverHandler` buffers the response body, so keep
   it off SSE / WebSocket / streaming routes.
+- **Stable-path rotation:** `RotatingFileHandler(dir, prefix, WithStableCurrentName())`
+  keeps the live file at a fixed `prefix.log` path (backups stay indexed) so external
+  tooling can follow it with `tail -F`; pair it with `WithMaxAge` and `WithCompress` for
+  age-based retention and gzipped backups.
 
 ## License
 

--- a/filelogger.go
+++ b/filelogger.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // FileLoggerOption configures NewFileLogger.
@@ -23,6 +24,27 @@ func WithMaxFileCapacity(n uint32) FileLoggerOption {
 // the log folder. Older files beyond the limit are pruned on rotation. The default is 7.
 func WithMaxFilesInFolder(n int) FileLoggerOption {
 	return func(c *fileLoggerConfig) { c.maxFilesInFolder = n }
+}
+
+// WithMaxFileAge forwards RotatingFileHandler's WithMaxAge to the underlying rotating
+// handler: rotated files whose mtime is older than d are pruned on rotation, on top of the
+// WithMaxFilesInFolder count bound. A d of zero or negative disables age pruning, which is
+// the default. The unit is a time.Duration, so pass the full span —
+// WithMaxFileAge(14 * 24 * time.Hour) for two weeks, not WithMaxFileAge(14) (14 ns).
+func WithMaxFileAge(d time.Duration) FileLoggerOption {
+	return func(c *fileLoggerConfig) { c.maxAge = d }
+}
+
+// WithFileCompression forwards RotatingFileHandler's WithCompress to the underlying
+// rotating handler: each rotated file is gzipped to prefix.<8 hex>.log.gz and the plaintext
+// removed, synchronously on the triggering write. It is OFF by default.
+//
+// RotatingFileHandler's WithStableCurrentName is deliberately NOT exposed here: NewFileLogger
+// wraps the handler in TimestampedHandler, prefixing every line with a timestamp, which is at
+// odds with a stable tail-able access-log format. Consumers wanting the fixed prefix.log live
+// path build a RotatingFileHandler directly instead.
+func WithFileCompression() FileLoggerOption {
+	return func(c *fileLoggerConfig) { c.compress = true }
 }
 
 // WithTempDirFallback enables the temp-directory fallback: when the folder argument to
@@ -139,10 +161,23 @@ func NewFileLogger(folder, prefix string, minLevel LogLevel, opts ...FileLoggerO
 		return nil, fmt.Errorf("loginjector: set permissions on log folder %q: %w", folder, err)
 	}
 
+	rotatingOpts := []RotatingFileOption{
+		WithMaxFileSize(cfg.maxFileCapacity),
+		WithMaxFiles(cfg.maxFilesInFolder),
+	}
+	// only append the additive options when active, so the zero-new-option call is
+	// byte-identical to the size/count-only handler it replaced.
+	if cfg.maxAge > 0 {
+		rotatingOpts = append(rotatingOpts, WithMaxAge(cfg.maxAge))
+	}
+	if cfg.compress {
+		rotatingOpts = append(rotatingOpts, WithCompress())
+	}
+
 	handlers := []io.Writer{
 		// stamp file lines sink-side (blessed emitters use Lmsgprefix only, so nothing
 		// else stamps the file); the RotatingFileHandler stays the underlying sink.
-		TimestampedHandler(RotatingFileHandler(folder, prefix, WithMaxFileSize(cfg.maxFileCapacity), WithMaxFiles(cfg.maxFilesInFolder))),
+		TimestampedHandler(RotatingFileHandler(folder, prefix, rotatingOpts...)),
 	}
 	if cfg.printer {
 		p := TimestampedPrintHandler(cfg.printerOpts...)
@@ -166,6 +201,8 @@ func NewFileLogger(folder, prefix string, minLevel LogLevel, opts ...FileLoggerO
 type fileLoggerConfig struct {
 	maxFileCapacity    uint32
 	maxFilesInFolder   int
+	maxAge             time.Duration // WithMaxFileAge; forwarded to RotatingFileHandler.
+	compress           bool          // WithFileCompression; forwarded to RotatingFileHandler.
 	tempFallback       bool
 	printer            bool
 	printerOpts        []PrintOption

--- a/filelogger_test.go
+++ b/filelogger_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prorochestvo/loginjector/internal/synctest"
 	"github.com/stretchr/testify/require"
@@ -402,5 +403,78 @@ func TestNewFileLogger_WithPrinterMinLevel(t *testing.T) {
 			"WithPrinterMinLevel equal to minLevel must still gate below-threshold messages")
 		require.Contains(t, consoleBuf.String(), "at")
 		require.Contains(t, consoleBuf.String(), "above")
+	})
+}
+
+// TestNewFileLogger_RotationOptions covers the WithMaxFileAge and WithFileCompression
+// forwarders added for lumberjack parity: they must reach the underlying
+// RotatingFileHandler while WithStableCurrentName is deliberately not exposed here.
+func TestNewFileLogger_RotationOptions(t *testing.T) {
+	const minLevel LogLevel = 1
+
+	t.Run("WithFileCompression forwards compression", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		l, err := NewFileLogger(dir, "app", minLevel,
+			WithoutPrinter(), WithMaxFileCapacity(20), WithMaxFilesInFolder(50), WithFileCompression())
+		require.NoError(t, err)
+
+		for i := 0; i < 4; i++ {
+			_, err = l.WriteLog(minLevel, []byte(fmt.Sprintf("padding-message-%d", i)))
+			require.NoError(t, err)
+		}
+
+		gzs, err := filepath.Glob(filepath.Join(dir, "*.log.gz"))
+		require.NoError(t, err)
+		require.NotEmpty(t, gzs, "WithFileCompression must gzip rotated backups")
+		// the compressed content is the timestamped file line, proving the whole chain
+		// (TimestampedHandler -> RotatingFileHandler compression) is intact.
+		require.Regexp(t, `^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `, readGzOrFail(t, gzs[0]))
+	})
+
+	t.Run("WithMaxFileAge forwards age pruning", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		l, err := NewFileLogger(dir, "app", minLevel,
+			WithoutPrinter(), WithMaxFileCapacity(20), WithMaxFilesInFolder(100), WithMaxFileAge(time.Hour))
+		require.NoError(t, err)
+
+		// each stamped line exceeds 20 bytes, so every write rotates: three backups form.
+		for i := 0; i < 3; i++ {
+			_, err = l.WriteLog(minLevel, []byte(fmt.Sprintf("msg%d-padding-xxxxx", i)))
+			require.NoError(t, err)
+		}
+		old := time.Now().Add(-2 * time.Hour)
+		require.NoError(t, os.Chtimes(filepath.Join(dir, "app.00000001.log"), old, old))
+
+		// more writes rotate again and run the age prune (count bound is 100, so age is
+		// the only pressure).
+		for i := 0; i < 3; i++ {
+			_, err = l.WriteLog(minLevel, []byte(fmt.Sprintf("more%d-padding-xxxxx", i)))
+			require.NoError(t, err)
+		}
+
+		_, err = os.Stat(filepath.Join(dir, "app.00000001.log"))
+		require.ErrorIs(t, err, os.ErrNotExist, "WithMaxFileAge must prune the backdated backup")
+	})
+
+	t.Run("no new options leaves NewFileLogger behavior unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		l, err := NewFileLogger(dir, "app", minLevel, WithoutPrinter())
+		require.NoError(t, err)
+
+		_, err = l.WriteLog(minLevel, []byte("hello world"))
+		require.NoError(t, err)
+
+		files, err := extractFilesOrFail(dir)
+		require.NoError(t, err)
+		require.Contains(t, files, "app.00000001.log")
+		gzs, err := filepath.Glob(filepath.Join(dir, "*.log.gz"))
+		require.NoError(t, err)
+		require.Empty(t, gzs, "without WithFileCompression no .gz must be produced")
 	})
 }

--- a/handler.go
+++ b/handler.go
@@ -366,11 +366,6 @@ func FileByFormatHandler(folder string, maxFilesInFolder int, fileNameGenerator 
 			if err != nil {
 				return 0, err
 			}
-			defer func(f *os.File) {
-				if e := f.Close(); e != nil {
-					err = errors.Join(err, e)
-				}
-			}(f)
 
 			var l uint64 = 0
 
@@ -384,6 +379,13 @@ func FileByFormatHandler(folder string, maxFilesInFolder int, fileNameGenerator 
 				err = errors.Join(err, e)
 			} else {
 				l += uint64(n)
+			}
+
+			// close explicitly, not via defer: this closure has unnamed returns, so a
+			// deferred assignment to err runs after `return int(l), err` has already
+			// copied the value and would silently drop the close error.
+			if e := f.Close(); e != nil {
+				err = errors.Join(err, e)
 			}
 
 			if lastFileName != fileName {

--- a/handler.go
+++ b/handler.go
@@ -2,6 +2,7 @@ package loginjector
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,7 +104,10 @@ func WithMaxFiles(n int) RotatingFileOption {
 // genuinely empty ring at index 1. Existing rotated content is permanently destroyed —
 // this is the intended behaviour; omit the option to resume and preserve prior content
 // across restarts. Files in folder that do not match the prefix.<8 hex>.log shape are
-// left untouched.
+// left untouched. When combined with WithCompress the compressed prefix.<8 hex>.log.gz
+// backups and any interrupted prefix.*.log.gz.tmp temps are removed too; with
+// WithStableCurrentName the fixed prefix.log live file is removed as well — so the ring
+// is genuinely empty under every option combination.
 //
 // A missing file or folder is a no-op: no file is created at construction, and the first
 // write creates index-1. Any removal error is stashed and surfaced on the first Write's
@@ -111,6 +115,62 @@ func WithMaxFiles(n int) RotatingFileOption {
 // seeded size to 0, overriding the resume-at-highest-index behaviour.
 func WithFreshStart() RotatingFileOption {
 	return func(c *rotatingFileConfig) { c.freshStart = true }
+}
+
+// WithStableCurrentName keeps the live file at a fixed path, prefix.log, instead of
+// naming it after the current rotation index. On rotation the live file is renamed to
+// the next indexed backup (prefix.<8 hex>.log) and a fresh prefix.log is opened, so
+// external tooling can follow the log at a stable path with tail -F (not tail -f: the
+// inode changes on every rotation). Rotated backups stay indexed exactly as in the
+// default scheme.
+//
+// On resume the handler seeds its size counter from prefix.log and appends to it; the
+// next backup index is one past the highest existing prefix.<8 hex>.log[.gz]. Legacy
+// indexed files already in the folder are adopted as backups and never chosen as the
+// live target. Switching a folder between the indexed and stable schemes between runs is
+// unsupported without WithFreshStart or a clean folder; a stale prefix.log left by a
+// prior stable run must be drained manually when switching back to the indexed scheme.
+//
+// Single-writer invariant: exactly one process may own a (folder, prefix) pair. Two
+// processes renaming prefix.log concurrently race and lose backups; this is not defended
+// in code (lumberjack has the same limitation).
+func WithStableCurrentName() RotatingFileOption {
+	return func(c *rotatingFileConfig) { c.stableName = true }
+}
+
+// WithMaxAge prunes rotated backups whose file modification time is older than d on each
+// rotation, on top of the WithMaxFiles count bound (a backup is removed when either bound
+// is exceeded). The live file is never pruned. A d of zero or negative disables age
+// pruning; that is the default.
+//
+// The unit is a time.Duration, so pass the full span — WithMaxAge(14 * 24 * time.Hour)
+// for two weeks. WithMaxAge(14) is fourteen nanoseconds, i.e. an instant wipe of every
+// backup on the first rotation.
+//
+// Age is measured by mtime, which is unreliable across NFS clock skew, a cp without -p,
+// or a restore that resets timestamps. When WithCompress is also set the compressed
+// backup keeps the source file's mtime (via os.Chtimes), so a genuinely old log
+// compressed today still ages out.
+func WithMaxAge(d time.Duration) RotatingFileOption {
+	return func(c *rotatingFileConfig) { c.maxAge = d }
+}
+
+// WithCompress gzips each rotated backup to prefix.<8 hex>.log.gz and removes the
+// plaintext, synchronously, on the Write that triggers the rotation. It is OFF by
+// default; with no options the handler never compresses and a pre-existing foreign
+// *.log.gz in the folder is ignored.
+//
+// Compression is crash-safe: the gzip is written to a temp file, fsync'd, and renamed
+// into place before the plaintext is removed, so a reader of *.log.gz never sees a
+// partial file. If a crash leaves both prefix.<idx>.log and prefix.<idx>.log.gz for one
+// index, the .gz is authoritative and the plaintext is discarded on the next
+// construction. A .log/.log.gz pair counts as a single file for the WithMaxFiles bound.
+//
+// Because it runs under the handler mutex, compression adds a bounded latency spike to
+// the one Write per rotation; the async background variant is deferred. The handler never
+// appends into a .gz file.
+func WithCompress() RotatingFileOption {
+	return func(c *rotatingFileConfig) { c.compress = true }
 }
 
 // RotatingFileHandler saves messages to files by number. The file name is
@@ -129,14 +189,19 @@ func WithFreshStart() RotatingFileOption {
 // encountered while resolving the resume point is stashed and joined into the
 // first Write's return value.
 //
-// Defaults: max file size 5 MiB, max files 7. Override with WithMaxFileSize and
-// WithMaxFiles; use WithFreshStart to begin each run from a truncated index-1
-// file. FileByFormatHandler is the sibling for filename-generator-driven rotation
-// and has no fresh-start variant (its target name is not known until the first
-// write).
+// Defaults: max file size 5 MiB, max files 7, no age bound, no compression, index-named
+// live file. Override with WithMaxFileSize and WithMaxFiles; use WithFreshStart to begin
+// each run from a truncated index-1 file. The opt-in options WithStableCurrentName (fixed
+// prefix.log live path for tail -F), WithMaxAge (mtime-based retention), and WithCompress
+// (gzip rotated backups to prefix.<8 hex>.log.gz) layer on additively; with none of them
+// the on-disk output is byte-identical to a plain rotating handler. FileByFormatHandler is
+// the sibling for filename-generator-driven rotation and has no fresh-start variant (its
+// target name is not known until the first write).
 //
-// The returned writer is mutex-guarded; the logger never calls its Write
-// concurrently.
+// The returned writer is mutex-guarded; the logger never calls its Write concurrently,
+// and compression (when enabled) runs synchronously inside that lock. A single process
+// must own a given (folder, prefix) pair; concurrent writers from multiple processes are
+// unsupported under WithStableCurrentName and WithCompress.
 func RotatingFileHandler(folder, prefix string, opts ...RotatingFileOption) io.Writer {
 	cfg := rotatingFileConfig{
 		maxFileSize: 5 << 20,
@@ -160,21 +225,84 @@ func RotatingFileHandler(folder, prefix string, opts ...RotatingFileOption) io.W
 	var seedErr error
 	if cfg.freshStart {
 		// overwrite-on-start forces a clean start regardless of what is on disk, so the
-		// resume scan is skipped and every existing prefix.<8 hex>.log file is removed —
-		// not just index-1 truncated — so the ring truly begins empty. Leaving stale
-		// higher-index files behind would let verifyFiles prune the fresh files ahead of
-		// them and let a later rotation append onto old content. Index/size stay 1/0; a
-		// missing file or folder is a no-op. Any remove error is surfaced on first Write.
-		seedErr = resetRotation(folder, prefix)
+		// resume scan is skipped and every existing prefix.<8 hex>.log[.gz] file (plus the
+		// stable live file and stale .log.gz.tmp temps) is removed — not just index-1
+		// truncated — so the ring truly begins empty. Leaving stale higher-index files
+		// behind would let pruning remove the fresh files ahead of them and let a later
+		// rotation append onto old content. Index/size stay 1/0; a missing file or folder
+		// is a no-op. Any remove error is surfaced on first Write.
+		seedErr = resetRotation(folder, prefix, cfg)
 	} else {
 		// resume at the highest existing index so the handler keeps appending to the
 		// newest file across a process restart, instead of restarting at index 1 —
-		// which is the lexicographically-oldest file that verifyFiles prunes first,
+		// which is the lexicographically-oldest file that pruning removes first,
 		// destroying the newest data.
-		index, fileSize, seedErr = resumeRotation(folder, prefix)
+		index, fileSize, seedErr = resumeRotation(folder, prefix, cfg)
 	}
 
-	fileName := rotatingFileName(prefix, index)
+	// with compression on, reconcile a crash-interrupted gzip: a stale plaintext left
+	// beside a complete .gz is discarded (the .gz wins) and orphaned .log.gz.tmp files are
+	// removed. resumeRotation already refuses to append into a .gz-topped index, so this
+	// is order-independent cleanup; it is skipped entirely with compression off, keeping
+	// seedErr byte-identical to the plain handler.
+	if cfg.compress && !cfg.freshStart {
+		seedErr = errors.Join(reconcileCompressed(folder, prefix), seedErr)
+	}
+
+	fileName := liveFileName(prefix, index, cfg.stableName)
+
+	// rotate advances the ring one step and prunes; it mutates index/fileName/fileSize in
+	// place under the handler mutex. Split out of the Write closure only for readability.
+	rotate := func() error {
+		var err error
+		if cfg.stableName {
+			// never clobber a pre-existing backup left by a crash or an earlier run.
+			for backupExists(folder, prefix, index, cfg.compress) {
+				index++
+			}
+			backupBase := rotatingFileName(prefix, index)
+			src := filepath.Join(folder, fileName)
+			if _, e := os.Stat(src); e == nil {
+				if e := os.Rename(src, filepath.Join(folder, backupBase)); e != nil {
+					err = errors.Join(err, e)
+				} else if cfg.compress {
+					err = errors.Join(err, compressFile(folder, backupBase))
+				}
+			} else if !os.IsNotExist(e) {
+				err = errors.Join(err, e)
+			}
+			index++ // advance to the next free backup slot for the following rotation.
+			fileSize = 0
+			// fileName stays the fixed prefix.log live path.
+		} else {
+			oldIndex := index
+			index++
+			if cfg.compress {
+				err = errors.Join(err, compressFile(folder, rotatingFileName(prefix, oldIndex)))
+			}
+			fileName = rotatingFileName(prefix, index)
+			// seed the new target's size from disk rather than assuming 0: when the
+			// handler rotates into a pre-existing higher-index file (from a prior run) an
+			// assumed-0 counter would let that file grow to ~2× the cap before rotating
+			// again.
+			fileSize = 0
+			if fi, e := os.Stat(filepath.Join(folder, fileName)); e == nil {
+				fileSize = uint64(fi.Size())
+			} else if !os.IsNotExist(e) {
+				err = errors.Join(err, e)
+			}
+		}
+
+		// zero-option handlers keep the original whole-folder verifyFiles pruning
+		// byte-for-byte; any opt-in (age, compression, stable name) uses the richer prune
+		// that understands .gz pairs, the age cutoff, and the live-file exclusion.
+		if !cfg.stableName && cfg.maxAge <= 0 && !cfg.compress {
+			err = errors.Join(err, verifyFiles(folder, cfg.maxFiles))
+		} else {
+			err = errors.Join(err, pruneRotation(folder, prefix, cfg, filepath.Base(fileName), time.Now()))
+		}
+		return err
+	}
 
 	w := &writer{
 		h: func(msg []byte) (int, error) {
@@ -187,11 +315,6 @@ func RotatingFileHandler(folder, prefix string, opts ...RotatingFileOption) io.W
 			if openErr != nil {
 				return 0, errors.Join(err, openErr)
 			}
-			defer func(f *os.File) {
-				if e := f.Close(); e != nil {
-					err = errors.Join(err, e)
-				}
-			}(f)
 
 			var l uint64 = 0
 
@@ -207,22 +330,16 @@ func RotatingFileHandler(folder, prefix string, opts ...RotatingFileOption) io.W
 				l += uint64(n)
 			}
 
+			// close the live file before any rotation: a stable-name rename and the gzip
+			// pass both need the descriptor released first.
+			if e := f.Close(); e != nil {
+				err = errors.Join(err, e)
+			}
+
 			fileSize += l
 
 			if fileSize > uint64(cfg.maxFileSize) {
-				index++
-				fileName = rotatingFileName(prefix, index)
-				// seed the new target's size from disk rather than assuming 0: when the
-				// handler rotates into a pre-existing higher-index file (from a prior
-				// run) an assumed-0 counter would let that file grow to ~2× the cap
-				// before rotating again.
-				fileSize = 0
-				if fi, e := os.Stat(filepath.Join(folder, fileName)); e == nil {
-					fileSize = uint64(fi.Size())
-				} else if !os.IsNotExist(e) {
-					err = errors.Join(err, e)
-				}
-				err = errors.Join(err, verifyFiles(folder, cfg.maxFiles))
+				err = errors.Join(err, rotate())
 			}
 
 			return int(l), err
@@ -436,6 +553,9 @@ type rotatingFileConfig struct {
 	maxFileSize uint32
 	maxFiles    int
 	freshStart  bool
+	stableName  bool          // WithStableCurrentName: live file is the fixed prefix.log.
+	maxAge      time.Duration // WithMaxAge: prune backups older than this; <= 0 disables.
+	compress    bool          // WithCompress: gzip rotated backups to prefix.<idx>.log.gz.
 }
 
 // rotatingFileName renders the on-disk name for a given rotation index, e.g.
@@ -445,52 +565,73 @@ func rotatingFileName(prefix string, index int) string {
 	return fmt.Sprintf("%s.%08X.%s", prefix, index, defaultFileExtension)
 }
 
-// resumeRotation resolves the starting rotation index and seed size for prefix in
-// folder by scanning for existing prefix.<8 hex>.log files and picking the highest
-// index. It returns (1, 0, nil) when none are found. The returned size is the
-// on-disk size of the resolved file, so the first write accounts for existing
-// content. Filenames that do not match the exact shape are ignored. A glob error
-// or an unexpected stat error is returned as seedErr for the caller to surface on
-// the first Write; index and size then fall back to the best values parsed so far.
-func resumeRotation(folder, prefix string) (index int, size uint64, seedErr error) {
-	index = 1
-
-	// glob only the extension (a literal pattern) so metacharacters in prefix cannot
-	// corrupt the match set, then filter to prefix.<8 hex>.log explicitly. The prefix
-	// guard is load-bearing: without it a foreign "XXXXXXXX.log" would survive the
-	// TrimPrefix no-op and be misparsed as a valid index.
-	matches, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension))
+// resumeRotation resolves the starting rotation index and seed size for prefix in folder
+// by scanning existing prefix.<8 hex>.log[.gz] backups and picking the highest index.
+// .gz files are considered only when cfg.compress is set. It returns (1, 0, nil) when no
+// backups exist.
+//
+// Indexed mode: when the highest index is uncompressed the handler resumes appending to
+// it and seeds size from its on-disk size; when the highest index is a .gz (the handler
+// never appends into a compressed file) it resumes at highest+1 with size 0, ignoring any
+// stale plaintext left beside the .gz.
+//
+// Stable-name mode: the live file is the fixed prefix.log, so size is seeded from it (not
+// from any backup) and the next backup index is highest+1. Filenames not matching the
+// exact shape are ignored. A glob or unexpected stat error is returned as seedErr for the
+// caller to surface on the first Write.
+func resumeRotation(folder, prefix string, cfg rotatingFileConfig) (index int, size uint64, seedErr error) {
+	// glob literal patterns so metacharacters in prefix cannot corrupt the match set,
+	// then filter to prefix.<8 hex>.log[.gz] explicitly via parseRotationIndex. The prefix
+	// guard is load-bearing: without it a foreign "XXXXXXXX.log" would be misparsed as a
+	// valid index.
+	matches, err := globRotation(folder, cfg.compress)
 	if err != nil {
-		return index, 0, err
+		return 1, 0, err
 	}
 
+	highest := 0
 	found := false
+	highestGz := false // whether the highest index has a compressed (.gz) form.
 	for _, p := range matches {
-		base := filepath.Base(p)
-		if !strings.HasPrefix(base, prefix+".") {
-			// not our prefix; skip before the TrimPrefix no-op can misparse it.
+		idx, gz, ok := parseRotationIndex(filepath.Base(p), prefix)
+		if !ok {
 			continue
 		}
-		mid := strings.TrimSuffix(strings.TrimPrefix(base, prefix+"."), "."+defaultFileExtension)
-		if len(mid) != 8 {
-			// reject non-8-hex middles: foreign files or malformed indices.
-			continue
-		}
-		n, e := strconv.ParseUint(mid, 16, 32)
-		if e != nil {
-			continue
-		}
-		if !found || int(n) > index {
-			index = int(n)
+		if !found || idx > highest {
+			highest = idx
 			found = true
+			highestGz = gz
+		} else if idx == highest && gz {
+			// a .gz for the current top index wins over a co-existing stale plaintext.
+			highestGz = true
 		}
+	}
+
+	if cfg.stableName {
+		// the live file is prefix.log; the next backup slot is one past the highest.
+		index = highest + 1
+		if !found {
+			index = 1
+		}
+		if fi, e := os.Stat(filepath.Join(folder, stableLiveName(prefix))); e == nil {
+			size = uint64(fi.Size())
+		} else if !os.IsNotExist(e) {
+			seedErr = e
+		}
+		return index, size, seedErr
 	}
 
 	if !found {
 		return 1, 0, nil
 	}
 
-	// seed size from the resolved highest-index file (0 if it does not exist yet).
+	if highestGz {
+		// the top index is compressed; never append into a .gz — resume one past it.
+		return highest + 1, 0, nil
+	}
+
+	// the top index is plain; resume appending to it, seeding size from disk.
+	index = highest
 	if fi, e := os.Stat(filepath.Join(folder, rotatingFileName(prefix, index))); e == nil {
 		size = uint64(fi.Size())
 	} else if !os.IsNotExist(e) {
@@ -499,41 +640,44 @@ func resumeRotation(folder, prefix string) (index int, size uint64, seedErr erro
 	return index, size, seedErr
 }
 
-// resetRotation removes every prefix.<8 hex>.log file in folder so a WithFreshStart
+// resetRotation removes every prefix.<8 hex>.log[.gz] file in folder so a WithFreshStart
 // handler begins with a genuinely empty ring instead of only truncating index-1 — which
-// would leave stale higher-index files for verifyFiles to prune ahead of the fresh ones
-// and for a later rotation to append onto. It globs the literal "*.log" (so prefix
-// metacharacters cannot corrupt the match set) and filters to the strict shape, mirroring
-// resumeRotation. Foreign filenames are left untouched. Remove errors are joined and
-// returned for the caller to surface on the first Write; a missing file is not an error.
-func resetRotation(folder, prefix string) error {
-	matches, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension))
+// would leave stale higher-index files for pruning to remove ahead of the fresh ones and
+// for a later rotation to append onto. It globs literal patterns (so prefix metacharacters
+// cannot corrupt the match set) and filters to the strict indexed shape, mirroring
+// resumeRotation. Under WithCompress the .gz backups and any interrupted .log.gz.tmp temps
+// are removed too; under WithStableCurrentName the fixed prefix.log live file is removed as
+// well. Foreign filenames are left untouched. Remove errors are joined and returned for the
+// caller to surface on the first Write; a missing file is not an error.
+func resetRotation(folder, prefix string, cfg rotatingFileConfig) error {
+	matches, err := globRotation(folder, cfg.compress)
 	if err != nil {
 		return err
 	}
 	for _, p := range matches {
-		base := filepath.Base(p)
-		if !strings.HasPrefix(base, prefix+".") {
+		if _, _, ok := parseRotationIndex(filepath.Base(p), prefix); !ok {
 			continue
 		}
-		mid := strings.TrimSuffix(strings.TrimPrefix(base, prefix+"."), "."+defaultFileExtension)
-		if len(mid) != 8 {
-			continue
-		}
-		if _, e := strconv.ParseUint(mid, 16, 32); e != nil {
-			continue
-		}
-		if e := os.Remove(p); e != nil && !os.IsNotExist(e) {
-			err = errors.Join(err, e)
-		}
+		err = errors.Join(err, removeIfExists(p))
+	}
+	if cfg.stableName {
+		// the stable live file has no index and would survive the loop above.
+		err = errors.Join(err, removeIfExists(filepath.Join(folder, stableLiveName(prefix))))
+	}
+	if cfg.compress {
+		err = errors.Join(err, removeCompressTemps(folder, prefix))
 	}
 	return err
 }
 
-// verifyFiles removes older files if the number of files exceeds limit
+// verifyFiles removes older files if the number of files exceeds limit. It is the blunt,
+// extension-agnostic count prune shared by the zero-option RotatingFileHandler and
+// FileByFormatHandler: it sorts every *.log lexically and removes the oldest past the
+// bound, without parsing indices (so date-named and foreign files are pruned too). The
+// richer pruneRotation handles the opt-in age/compress/stable paths. .gz files are never
+// in scope here — it always globs plaintext only.
 func verifyFiles(folder string, limit int) error {
-	// read files by format
-	files, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension))
+	files, err := globRotation(folder, false)
 	if err != nil || len(files) == 0 {
 		return err
 	}
@@ -547,6 +691,284 @@ func verifyFiles(folder string, limit int) error {
 
 const defaultFilePermissions = 0640
 const defaultFileExtension = "log"
+const gzipExtension = "gz"
+const tmpExtension = "tmp"
+
+// stableLiveName is the fixed live-file name under WithStableCurrentName: prefix.log.
+func stableLiveName(prefix string) string {
+	return prefix + "." + defaultFileExtension
+}
+
+// liveFileName is the current write target: the fixed prefix.log under stable-name mode,
+// otherwise the index-named prefix.<8 hex>.log.
+func liveFileName(prefix string, index int, stableName bool) string {
+	if stableName {
+		return stableLiveName(prefix)
+	}
+	return rotatingFileName(prefix, index)
+}
+
+// parseRotationIndex parses a rotated backup's index from its base name. It strips an
+// optional trailing .gz first (reporting gz), then applies the strict
+// prefix.<8 hex>.log shape check. Stripping .gz before the check is load-bearing: without
+// it prefix.<8 hex>.log.gz has a 15-character middle and is silently dropped. The live
+// prefix.log (middle "log", length 3) is intentionally not an index and returns ok=false;
+// it is resolved by liveFileName, not this scan.
+func parseRotationIndex(base, prefix string) (index int, gz bool, ok bool) {
+	if strings.HasSuffix(base, "."+gzipExtension) {
+		gz = true
+		base = strings.TrimSuffix(base, "."+gzipExtension)
+	}
+	if !strings.HasPrefix(base, prefix+".") {
+		return 0, gz, false
+	}
+	mid := strings.TrimSuffix(strings.TrimPrefix(base, prefix+"."), "."+defaultFileExtension)
+	if len(mid) != 8 {
+		return 0, gz, false
+	}
+	n, err := strconv.ParseUint(mid, 16, 32)
+	if err != nil {
+		return 0, gz, false
+	}
+	return int(n), gz, true
+}
+
+// globRotation returns the rotation files in folder by globbing the literal "*.log" (and
+// "*.log.gz" when includeGz), never interpolating a caller-supplied prefix into the
+// pattern — the glob-injection guard the resume and prune scans depend on. Callers filter
+// the result to a specific prefix with parseRotationIndex.
+func globRotation(folder string, includeGz bool) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension))
+	if err != nil {
+		return nil, err
+	}
+	if includeGz {
+		gz, e := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension+"."+gzipExtension))
+		if e != nil {
+			return matches, e
+		}
+		matches = append(matches, gz...)
+	}
+	return matches, nil
+}
+
+// backupExists reports whether a rotated backup already occupies index for prefix in
+// folder, as either the plaintext or (when includeGz) the compressed form. The rotation
+// collision guard uses it so a crash/resume leftover is never clobbered by a rename.
+func backupExists(folder, prefix string, index int, includeGz bool) bool {
+	if _, err := os.Stat(filepath.Join(folder, rotatingFileName(prefix, index))); err == nil {
+		return true
+	}
+	if includeGz {
+		if _, err := os.Stat(filepath.Join(folder, rotatingFileName(prefix, index)+"."+gzipExtension)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// backupEntry groups the on-disk files that make up one rotated backup index: the
+// plaintext prefix.<idx>.log and/or its compressed prefix.<idx>.log.gz sibling. mtime is
+// the newest modification time among them, used by the age prune so a pair is aged as a
+// unit. The index is the map key in listBackups, so it is not repeated here.
+type backupEntry struct {
+	paths []string
+	mtime time.Time
+}
+
+// pruneRotation enforces the retention bounds on prefix's rotated backups in folder: first
+// age (when cfg.maxAge > 0, any backup whose mtime precedes now-maxAge is removed), then
+// count (keep only the newest cfg.maxFiles-1 backups, since the live file is the +1). The
+// live file, identified by liveBase, is excluded by name so a quiet log's live file is
+// never pruned even when it is the oldest on disk. A .log/.log.gz pair for one index counts
+// as a single backup and is removed together. .gz files are considered only when
+// cfg.compress is set.
+func pruneRotation(folder, prefix string, cfg rotatingFileConfig, liveBase string, now time.Time) error {
+	groups, err := listBackups(folder, prefix, cfg.compress, liveBase)
+	if err != nil {
+		return err
+	}
+
+	indices := make([]int, 0, len(groups))
+	for i := range groups {
+		indices = append(indices, i)
+	}
+	sort.Ints(indices) // ascending index == oldest data first.
+
+	remove := func(idx int) {
+		for _, p := range groups[idx].paths {
+			err = errors.Join(err, removeIfExists(p))
+		}
+	}
+
+	// age phase: drop everything older than the cutoff, keeping the survivors in order.
+	survivors := make([]int, 0, len(indices))
+	if cfg.maxAge > 0 {
+		cutoff := now.Add(-cfg.maxAge)
+		for _, i := range indices {
+			if groups[i].mtime.Before(cutoff) {
+				remove(i)
+				continue
+			}
+			survivors = append(survivors, i)
+		}
+	} else {
+		survivors = append(survivors, indices...)
+	}
+
+	// count phase: keep the newest maxFiles-1 backups (the live file is the +1).
+	keep := cfg.maxFiles - 1
+	if keep < 0 {
+		keep = 0
+	}
+	for i := 0; i < len(survivors)-keep; i++ {
+		remove(survivors[i])
+	}
+	return err
+}
+
+// listBackups groups prefix's rotated backup files in folder by rotation index, skipping
+// the live file (excludeBase) and any non-matching name. .gz siblings are included only
+// when includeGz is set, preserving the byte-identical zero-option contract. Files that
+// vanish between the glob and the stat are ignored (nothing left to prune).
+func listBackups(folder, prefix string, includeGz bool, excludeBase string) (map[int]*backupEntry, error) {
+	matches, err := globRotation(folder, includeGz)
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[int]*backupEntry)
+	for _, p := range matches {
+		base := filepath.Base(p)
+		if base == excludeBase {
+			continue
+		}
+		idx, _, ok := parseRotationIndex(base, prefix)
+		if !ok {
+			continue
+		}
+		fi, e := os.Stat(p)
+		if e != nil {
+			continue
+		}
+		g := groups[idx]
+		if g == nil {
+			g = &backupEntry{}
+			groups[idx] = g
+		}
+		g.paths = append(g.paths, p)
+		if fi.ModTime().After(g.mtime) {
+			g.mtime = fi.ModTime()
+		}
+	}
+	return groups, nil
+}
+
+// compressFile gzips folder/base (a rotated plaintext prefix.<idx>.log) to
+// folder/base.gz and removes the plaintext, crash-safely: it writes to a 0640 O_EXCL temp
+// (never os.Create, which is world-readable, and O_EXCL also refuses a pre-planted
+// symlink), flushes and fsyncs, then renames the temp into place before removing the
+// plaintext — so a reader of *.log.gz never sees a partial file. The .gz keeps the source
+// file's mtime (os.Chtimes) so age pruning stays honest. A missing source is a no-op.
+func compressFile(folder, base string) error {
+	src := filepath.Join(folder, base)
+	fi, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	dst := src + "." + gzipExtension
+	tmp := dst + "." + tmpExtension
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, defaultFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	zw := gzip.NewWriter(out)
+	if _, e := io.Copy(zw, in); e != nil {
+		_ = zw.Close()
+		_ = out.Close()
+		return errors.Join(e, removeIfExists(tmp))
+	}
+	if e := zw.Close(); e != nil {
+		_ = out.Close()
+		return errors.Join(e, removeIfExists(tmp))
+	}
+	if e := out.Sync(); e != nil {
+		_ = out.Close()
+		return errors.Join(e, removeIfExists(tmp))
+	}
+	if e := out.Close(); e != nil {
+		return errors.Join(e, removeIfExists(tmp))
+	}
+	if e := os.Rename(tmp, dst); e != nil {
+		return errors.Join(e, removeIfExists(tmp))
+	}
+
+	// preserve the source mtime on the .gz so WithMaxAge still ages it out correctly,
+	// then drop the plaintext now that the compressed copy is durable.
+	err = errors.Join(err, os.Chtimes(dst, time.Now(), fi.ModTime()))
+	err = errors.Join(err, removeIfExists(src))
+	return err
+}
+
+// reconcileCompressed heals a crash-interrupted compression at construction: it removes
+// orphaned prefix.*.log.gz.tmp temps and, wherever both prefix.<idx>.log and its .gz exist,
+// discards the plaintext (the durable .gz is authoritative). It only runs under
+// WithCompress, so a plain handler never touches .gz files.
+func reconcileCompressed(folder, prefix string) error {
+	err := removeCompressTemps(folder, prefix)
+
+	// a leftover plaintext beside a complete .gz is a crash remnant; the .gz wins.
+	logs, e := globRotation(folder, false)
+	if e != nil {
+		return errors.Join(err, e)
+	}
+	for _, p := range logs {
+		idx, gz, ok := parseRotationIndex(filepath.Base(p), prefix)
+		if !ok || gz {
+			continue
+		}
+		gzPath := filepath.Join(folder, rotatingFileName(prefix, idx)+"."+gzipExtension)
+		if _, statErr := os.Stat(gzPath); statErr == nil {
+			err = errors.Join(err, removeIfExists(p))
+		}
+	}
+	return err
+}
+
+// removeCompressTemps deletes stale prefix.*.log.gz.tmp files left by an interrupted
+// compression. It globs the literal temp pattern and filters by prefix, so metacharacters
+// in prefix cannot corrupt the match set.
+func removeCompressTemps(folder, prefix string) error {
+	tmps, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension+"."+gzipExtension+"."+tmpExtension))
+	if err != nil {
+		return err
+	}
+	for _, p := range tmps {
+		if !strings.HasPrefix(filepath.Base(p), prefix+".") {
+			continue
+		}
+		err = errors.Join(err, removeIfExists(p))
+	}
+	return err
+}
+
+// removeIfExists removes path, treating an already-absent file as success.
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
 
 // WithMinLevel wraps handler so that Logger treats it as a LeveledHandler with
 // the given minimum level. The returned writer forwards Write calls to handler

--- a/httptap/example_access_test.go
+++ b/httptap/example_access_test.go
@@ -1,0 +1,31 @@
+package httptap
+
+import (
+	"net/http"
+	"time"
+
+	loginjector "github.com/prorochestvo/loginjector"
+)
+
+// ExampleNewAccessHandler shows the canonical production access-log sink: a
+// RotatingFileHandler configured for a stable, tail -F-able path with age-based retention
+// and gzipped backups, handed to NewAccessHandler. RotatingFileHandler returns a
+// mutex-guarded writer, so it satisfies NewAccessHandler's requirement that out be safe
+// for concurrent Write calls.
+func ExampleNewAccessHandler() {
+	// access.log stays at a fixed path so `tail -F access.log` follows it across rotations;
+	// rotated backups are indexed, gzipped, and pruned once older than two weeks.
+	out := loginjector.RotatingFileHandler(
+		"./logs", "access",
+		loginjector.WithStableCurrentName(),
+		loginjector.WithMaxAge(14*24*time.Hour),
+		loginjector.WithCompress(),
+	)
+
+	app := func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}
+
+	// Register the returned handler with http.Handle or your router.
+	_ = NewAccessHandler(out, app)
+}

--- a/plans/completed/260720.0001.rotating-file-handler-lumberjack-parity.md
+++ b/plans/completed/260720.0001.rotating-file-handler-lumberjack-parity.md
@@ -1,0 +1,301 @@
+# Task Breakdown — RotatingFileHandler lumberjack-parity options
+
+Status: ready for implementation. Supersedes the initial design draft after a
+10-reviewer plan audit (5 architect + 5 reviewer lenses). Every P0/P1 the audit
+raised is folded into the tasks below with `file:line` anchors.
+
+## Overview
+
+Close the operational gap that forced a consumer (the `vpntunnel` access log,
+within the hive service set) to accept three regressions when it migrated off
+`gopkg.in/natefinch/lumberjack.v2` onto `RotatingFileHandler` (handler.go:140):
+age-based retention, compression of rotated files, and a stable current-file
+name that external tooling can `tail -F`. We add these as **additive, opt-in
+`RotatingFileOption`s**; with zero options the handler stays byte-identical to
+v1.0.7.
+
+This is a library-capability plan (all core work is in `handler.go`); it also
+wires the two cheap adjacent surfaces the consumer needs (`NewFileLogger`
+forwarding, a documented `NewAccessHandler` sink pattern).
+
+**Scope decision:** this closes the gap for `vpntunnel`'s specific shape — a
+single-writer, tail-at-a-stable-path access log. It is NOT a general "drop
+lumberjack for any use case" claim (see Non-goals).
+
+## Locked decisions (from the review + consumer sign-off)
+
+- **D1 — Compression is synchronous in v1, OFF by default.** `WithCompress()` is
+  opt-in; zero options never compress. gzip runs inline on the rotating `Write`.
+  It is made crash-safe (atomic temp+rename, Task 3), so it survives restart, but
+  it holds the handler mutex for the gzip duration (a bounded latency spike at
+  rotation). The async background "mill" + a `Close()`/shutdown lifecycle is
+  **deferred** and tracked in a GitHub issue (Task 6). Rationale: ships the
+  functional parity fast, stays inside the `io.Writer` contract (no new public
+  lifecycle API), and is deterministically testable.
+- **D2 — Single-writer invariant.** One process owns a `(folder, prefix)` pair.
+  Multi-process writers on a shared volume are explicitly unsupported for
+  stable-name/compress (rename/gzip races lose backups); lumberjack has the same
+  limit. Documented in godoc, not defended in code.
+- **D3 — Backups stay INDEXED** `prefix.<8HEX>.log[.gz]`; the **live** file under
+  stable-name is `prefix.log`. Timestamped backup names (lumberjack's format) are
+  a Non-goal. The consumer only needs a stable *live* path.
+- **D4 — Age is measured by file mtime**, and compression preserves it
+  (`os.Chtimes`, Task 3) so `MaxAge` stays honest on `.gz` files.
+- **D5 — Task 4 (persistent fd / keep-open) is CUT** from this plan → deferred
+  (it needs the same `Close()` lifecycle as async compression, and it silently
+  breaks external-logrotate compatibility that per-write-open grants for free).
+
+## Non-goals (remaining lumberjack features NOT covered — state honestly)
+
+- Timestamped backup filenames (`name-2006-01-02T15-04-05.000.ext`); backups stay
+  indexed.
+- Explicit `Rotate()` / SIGHUP trigger — blocked by the bare `io.Writer` return
+  type; needs a lifecycle API.
+- `LocalTime` (backup timezone) — moot while names are index-based.
+- Async background compression + graceful shutdown of in-flight compression
+  (deferred; Task 6 issue).
+- Time-based (calendar) rotation — designed-for but not built (see Task 2/3 note
+  on keeping retention handler-agnostic).
+- Multi-process / shared-volume safety (D2).
+- `MaxBackups`-exact semantics: our `maxFiles` counts the live file (N-1 backups
+  + 1 live), lumberjack's `MaxBackups` counts backups only. Documented, not
+  changed.
+
+## Design foundation (Task 0 — do first)
+
+All three existing scan sites parse an index from a filename and each will
+otherwise reimplement `.gz` handling inconsistently:
+`resumeRotation` (handler.go:455), `resetRotation` (handler.go:509),
+`verifyFiles` (handler.go:534). Introduce shared internal helpers so the naming
+model lives in one place:
+
+- `parseRotationIndex(base, prefix string) (index int, gz bool, ok bool)` — strips
+  an **optional trailing `.gz` first**, then applies the existing
+  `HasPrefix(prefix+".")` + 8-hex-middle check (handler.go:470-482). This is the
+  fix for the P0 where `access.00000001.log.gz` (`mid` len 15) and `access.log`
+  (`mid` "log") are both silently dropped by today's parser.
+- `liveFileName(cfg, prefix) string` — `prefix.log` when stable-name is on, else
+  `rotatingFileName(prefix, index)`.
+- A single `globRotation(folder string, includeGz bool) ([]string, error)` that
+  globs the **literal** `*.log` (and `*.log.gz` only when `includeGz`) — never
+  interpolating `prefix` into the glob pattern, preserving the glob-injection
+  guard the code deliberately keeps (handler.go:462 comment).
+
+**Gating rule (load-bearing for byte-identical):** `.gz` is included in globbing
+and parsing **only when `cfg.compress` is set**. A pre-existing foreign
+`foo.log.gz` must not alter a zero-option handler's resume/prune. (reviewer R4)
+
+### Task 0 acceptance
+- `resumeRotation`, `resetRotation`, `verifyFiles` all route through the shared
+  helpers; behavior with zero options is unchanged (existing
+  `TestRotatingFileHandler*` pass **unmodified**).
+- A prefix containing glob metacharacters still cannot corrupt the match set
+  (existing `testRotatingFileHandlerResumeGlobMeta` still green; add a `.gz`
+  variant once compression lands).
+
+## Tasks
+
+### Task 1 — `WithStableCurrentName()`
+Live file becomes `prefix.log`; on rotation `os.Rename(prefix.log →
+prefix.<idx>.log)` then open a fresh `prefix.log`.
+
+- **Distinct resume branch** (not a tweak to the indexed path): when stable-name
+  is on, seed `fileSize` from `os.Stat(folder/prefix.log)` — NOT from the highest
+  indexed backup (handler.go:494, the current P0 that would seed from the wrong
+  file → up to 2× cap overshoot); next backup index = `highestBackup + 1`.
+- **Rotation collision guard:** if `prefix.<idx>.log` already exists (crash/resume
+  leftover), advance `idx` past it rather than clobbering.
+- **Prune never removes the live file:** exclude `prefix.log` from age-prune **by
+  name** (its mtime is fresh only on a busy log; a quiet log's live file could be
+  the oldest). It is already safe from count-prune because `prefix.log` sorts
+  lexically last, but pin that as a stated invariant.
+- **`maxFiles` counts the live file** (N-1 backups + 1 live), same as v1.0.7 — do
+  not "fix" it into +1 retention.
+- **Migration & rollback (the actual deploy path):** enabling stable-name over a
+  folder that already holds legacy `prefix.<8hex>.log` files must adopt them as
+  backups and never pick one as the live target. Toggling the scheme between runs
+  (on→off or off→on) is **unsupported without `WithFreshStart` or a clean folder**
+  — document it; on off→on, adopt a bare `prefix.log` on first write; on on→off,
+  document that a stale `prefix.log` must be drained manually.
+
+**AC:** live path fixed across N rotations while indexed backups accumulate;
+restart seeds size from `prefix.log` and appends (no truncation, no overshoot);
+next index = max+1; rotation past a pre-existing index does not clobber; small
+`maxFiles` × many rotations proves `prefix.log` survives; `-race` test for both
+toggle directions.
+
+### Task 2 — `WithMaxAge(d time.Duration)`
+On each rotation, remove rotated backups whose mtime is older than `now - d`.
+
+- `d <= 0` (not just `== 0`) means **disabled** — guards the `WithMaxAge(-1)`
+  foot-gun (reviewer R5).
+- Runs in the same pass as count-prune: **age first, then count** — both bounds
+  can trigger a delete (final set = not-over-age ∩ within-count; order-independent
+  per R4).
+- **Never deletes the live file** (exclude by name, see Task 1).
+- godoc must state the unit loudly with an example — `WithMaxAge(14 * 24 *
+  time.Hour)`, because `WithMaxAge(14)` = 14 ns = instant wipe.
+- godoc caveat: age is mtime-based, so it is unreliable across NFS clock skew /
+  `cp` without `-p` / restore; compression preserves mtime (Task 3) so `.gz`
+  files still age correctly.
+- Keep the retention comparison **handler-agnostic** (a helper that takes a set of
+  files + a cutoff) so future time-based rotation / `FileByFormatHandler` can
+  reuse it rather than growing a second incompatible option set.
+
+**AC:** `os.Chtimes`-backdated backups — over-age removed, under-age kept, live
+file untouched even with a tiny `d`; age×count union test; `d <= 0` is a no-op
+(byte-identical).
+
+### Task 3 — `WithCompress()` (OFF by default)
+After a file is rotated out of the live slot, gzip it to `<name>.log.gz` and
+remove the plaintext. Works in **both** indexed mode (compress index N when
+advancing to N+1) and stable-name mode (compress the just-renamed backup).
+
+- **Security (P0):** create the temp with the plaintext's ceiling —
+  `os.OpenFile(tmp, O_WRONLY|O_CREATE|O_EXCL, 0640)`, **never `os.Create`**
+  (0666→0644 world-readable PII). `O_EXCL` also refuses a pre-planted symlink.
+- **Atomicity (P0):** `<name>.log.gz.tmp` (0640, O_EXCL) → write → flush →
+  `f.Sync()` → close → `os.Rename(tmp, <name>.log.gz)` → `os.Remove(<name>.log)`.
+  Readers of `*.log.gz` only ever see a complete file.
+- **Crash reconciliation** (run on rotation AND at construction/resume): if both
+  `<idx>.log` and `<idx>.log.gz` exist, the `.gz` is authoritative — delete the
+  `.log`. A `.log`/`.log.gz` pair counts as **one** file for pruning.
+- **Age honesty (P1):** `os.Chtimes` the `.gz` to the source file's mtime before
+  removing the plaintext, so a genuinely old log compressed today still ages out.
+- **Prune runs unconditionally** of compression success (disk-full: gzip needs
+  transient extra space while plaintext still exists; retention must stay bounded
+  even when compression is stuck). Join compress/prune errors into the `Write`
+  return, same discipline as `seedErr` (handler.go:183).
+- **Never append into a `.gz`:** live-file selection stays on uncompressed files
+  only; a `.gz`-only highest index resumes at N+1.
+- Clean stale `prefix.*.log.gz.tmp` at construction.
+- **Restart:** synchronous compression completes within the `Write`, so there is
+  no cross-restart in-flight state to lose; the reconciliation rule makes a
+  crash mid-compress self-heal. (The v1 limitation is the latency spike, not data
+  loss — see Task 6.)
+
+**AC:** rotated file becomes a valid `.gz` whose decompressed bytes == the
+pre-rotation plaintext; prune counts `.log` and `.log.gz` and removes oldest
+regardless of extension; `.gz` is 0640; a simulated crash (leftover `.log` +
+`.log.gz` for one index) reconciles on next construction; `WithFreshStart` +
+`WithCompress` begins genuinely empty (resetRotation removes `.gz` too);
+`-race` test with `WithCompress` + `WithStableCurrentName` (+ `WithMaxAge`) on,
+compression pinned synchronous-under-mutex.
+
+### Task 4 — `NewFileLogger` parity (adjacent, cheap)
+Forward the age and compression options through `NewFileLogger`
+(filelogger.go:145 currently forwards only size/count) as new `FileLoggerOption`s.
+Named `WithMaxFileAge(d)` and `WithFileCompression()` — the bare `WithMaxAge` /
+`WithCompress` names are already taken by the `RotatingFileOption`s in the same
+package, so the wrapper mirrors the existing `WithMaxFileCapacity` /
+`WithMaxFilesInFolder` naming and forwards to `WithMaxAge` / `WithCompress` internally.
+`WithStableCurrentName` is **intentionally NOT forwarded** — `NewFileLogger`
+wraps the handler in `TimestampedHandler` (filelogger.go:143-145), which prefixes
+`<timestamp> ` and defeats a "stable tail-able format"; document the omission.
+
+**AC:** an app log created via `NewFileLogger(..., WithMaxAge(...))` prunes by age;
+zero new options → unchanged `NewFileLogger` behavior.
+
+### Task 5 — Docs (adjacent, cheap)
+- Update **existing** godoc that these options make stale: `RotatingFileHandler`
+  (handler.go:116-139) and `WithFreshStart` (handler.go:101-114) — the stable
+  live path, `.gz` backups, and the age axis. godoc is the pkg.go.dev contract.
+- godoc the three new options (units, `tail -F` not `-f`, mtime caveat, single-
+  writer invariant).
+- README: **one** Notes bullet — "for a `tail -F`-able fixed path use
+  `WithStableCurrentName`". Do not re-bloat the just-trimmed README (df493f7).
+- Document the canonical sink pattern with a runnable example test:
+  `NewAccessHandler(out, next)` where `out = RotatingFileHandler(dir, "access",
+  WithStableCurrentName(), WithMaxAge(...), WithCompress())`. `RotatingFileHandler`
+  returns a mutex-guarded writer, satisfying `NewAccessHandler`'s concurrent-write
+  contract (httptap/access.go:22-27).
+- `CHANGELOG.md`: append `### Added` bullets under the existing `[Unreleased]`
+  (read first; version left to the release workflow).
+
+### Task 6 — GitHub issue (deferred work) — DONE: prorochestvo/LogInjector#13
+Open an English issue in `prorochestvo/LogInjector` documenting the v1
+compression limitation and the deferred design: synchronous compression holds the
+handler mutex (and the logger `RLock`, logger.go:177) for the gzip duration → a
+rotation-time latency spike; the proper fix is an async background mill plus a
+`Close()`/shutdown lifecycle on the handler and `Logger`, which also unblocks the
+persistent-fd optimization and an explicit `Rotate()`. Link it from the CHANGELOG
+note is optional; the issue is the tracker.
+
+## Execution order
+0 → 1 → 2 → 3 → 4 → 5, then 6. Task 0 is a hard prerequisite (the shared parser
+is what makes 1/2/3 correct). Task 1 before 2/3 because both the age live-file
+exclusion and the compress target differ between indexed and stable modes; once
+Task 0's `liveFileName` exists, 1↔2 are interchangeable. Task 6 any time after D1
+is final (now).
+
+## Testing strategy (mechanisms, not just outcomes)
+- **Determinism:** age tests backdate with `os.Chtimes`, NOT a clock seam (mtime
+  is real filesystem data).
+- **Compression content:** decompress the `.gz` and assert bytes == plaintext —
+  an existence check passes a rename-only bug. The test helper
+  `extractFilesOrFail` (handler_test.go:939) globs `*.log` and is blind to `.gz`;
+  give it a `.gz`-aware variant or it silently asserts nothing.
+- **Regression guard ("byte-identical to v1.0.7"):** existing
+  `TestRotatingFileHandler*` pass **unmodified** at zero options, plus a golden
+  assertion on filenames/indices/on-disk bytes across N rotations; and a
+  zero-option handler over a folder containing a foreign `*.log.gz` is unaffected.
+- **Race:** a `…ForRaceCondition` test with the new options on (per CLAUDE.md,
+  race coverage on file handlers is load-bearing).
+- **Benchmarks:** `BenchmarkRotatingFileHandler_Write` (options off, non-rotating)
+  with `b.ReportAllocs()` as a hot-path allocation guard (options off must add
+  zero hot-path allocation); a rotation+compress benchmark to quantify the spike.
+- Cross-restart resume tests for stable-name and for an all-`.gz` backup set.
+
+## Risks & trade-offs
+- **Synchronous compression latency** (D1) — accepted, documented, tracked (Task
+  6). Worst case on the Pi/SD target is a sub-second stall on the one `Write` that
+  triggers rotation, once per `maxFileSize` of logs; async is the follow-up.
+- **mtime-based age** (D4) — simpler than parsing timestamps from names; caveated
+  for NFS/copy. `os.Chtimes` keeps it honest across compression.
+- **Single-writer** (D2) — documented invariant; multi-process is out.
+- **`current` symlink alternative — rejected:** rename keeps the live inode at a
+  fixed path for `tail -F` and avoids symlink portability pain under
+  `CGO_ENABLED=0`.
+
+## Consumer follow-up (vpntunnel, after this ships)
+- Map `config.AccessLog.MaxAgeDays` → `WithMaxAge(days * 24 * time.Hour)` (show
+  the ×24h conversion explicitly — it is not `WithMaxAge(days)`), `Compress` →
+  `WithCompress()`, and adopt `WithStableCurrentName()` so the file is `access.log`
+  again.
+- Revert the `access.*.log` glob workaround (`readAccessLogLines` /
+  `readAccessLogRaw`) back to the fixed path; drop the caveat note in
+  `observability/access.go`.
+
+## Housekeeping (out of band, not blocking)
+- `CLAUDE.md` still names the handler `CyclicOverwritingFilesHandler`; it was
+  collapsed into `RotatingFileHandler` in v1.0.6 (per CHANGELOG). Stale — fix in a
+  separate `docs:` change.
+- The documented gate `CGO_ENABLED=0 go test -race` cannot run on arm64 (race
+  needs cgo); the working command is `CGO_ENABLED=1 go test -race ./...`.
+
+## Completion
+
+Tasks 0–5 implemented; Task 6 filed as prorochestvo/LogInjector#13. Gate green
+(`gofmt`/`vet` clean, `CGO_ENABLED=1 go test -race ./...` and `CGO_ENABLED=0 go
+test ./...` both pass). Three-lens review (correctness / security-ops /
+performance-architecture): **APPROVE, zero P0/P1.** The four locked P0s were
+verified correct in code by every lens.
+
+Implementation notes worth recording:
+- The hot-path `defer f.Close()` became an explicit close before rotation. It is
+  **required** (the stable-name rename and gzip need the fd released; mandatory on
+  Windows under `CGO_ENABLED=0`) and it fixes a latent bug — the old unnamed-return
+  `defer` silently dropped the close error. Measured **allocation-neutral** (4
+  allocs/op both trees), not a perf win; the commit message must not claim one.
+
+Accepted P2/P3 review findings, deferred (not blocking):
+- `FileByFormatHandler` (handler.go:369) still drops its close error via the same
+  unnamed-return `defer` pattern — pre-existing, out of scope, worth a separate
+  `fix:` commit.
+- `compressFile` uses `gzip.DefaultCompression`; `gzip.BestSpeed` would roughly
+  halve the rotation CPU spike at ~10–15% larger `.gz` — left at default (disk
+  ratio is the point of compressing); a tunable to consider.
+- No directory fsync after the compress rename/remove (same gap as lumberjack);
+  pairs with the #13 async rework.
+- `handler.go` is ~1015 lines; the rotation subsystem could move to
+  `rotatingfile.go` (same package) — mechanical, deferred.

--- a/rotating_options_test.go
+++ b/rotating_options_test.go
@@ -1,0 +1,575 @@
+package loginjector
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readGzOrFail decompresses a gzip file and returns its plaintext, failing the test on
+// any error. Compression tests decompress and compare bytes because an existence-only
+// check would pass a rename-that-forgot-to-gzip bug.
+func readGzOrFail(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	zr, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	defer func() { _ = zr.Close() }()
+	b, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// extractFilesWithGzOrFail is the .gz-aware sibling of extractFilesOrFail: it maps every
+// *.log to its raw bytes and every *.log.gz to its DECOMPRESSED plaintext, keyed by base
+// name. The plain helper globs only *.log and is blind to compressed backups.
+func extractFilesWithGzOrFail(t *testing.T, folder string) map[string]string {
+	t.Helper()
+	r := make(map[string]string)
+
+	logs, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension))
+	require.NoError(t, err)
+	for _, p := range logs {
+		b, e := os.ReadFile(p)
+		require.NoError(t, e)
+		r[filepath.Base(p)] = string(b)
+	}
+
+	gzs, err := filepath.Glob(filepath.Join(folder, "*."+defaultFileExtension+"."+gzipExtension))
+	require.NoError(t, err)
+	for _, p := range gzs {
+		r[filepath.Base(p)] = readGzOrFail(t, p)
+	}
+	return r
+}
+
+// writeRotating writes s through h and asserts no error, keeping the option tests terse.
+func writeRotating(t *testing.T, h io.Writer, s string) {
+	t.Helper()
+	_, err := h.Write([]byte(s))
+	require.NoError(t, err)
+}
+
+// touchOld writes content to path and backdates its mtime by age, for deterministic
+// age-prune tests (mtime is real filesystem data, so no clock seam is needed).
+func touchOld(t *testing.T, path, content string, age time.Duration) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), defaultFilePermissions))
+	when := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, when, when))
+}
+
+func idxName(prefix string, index int) string {
+	return fmt.Sprintf("%s.%08X.%s", prefix, index, defaultFileExtension)
+}
+
+func TestRotatingFileHandler_StableCurrentName(t *testing.T) {
+	t.Run("live path fixed while indexed backups accumulate", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(10), WithMaxFiles(20), WithStableCurrentName())
+
+		writeRotating(t, h, "aaaaa") // access.log = "aaaaa\n" (6)
+		writeRotating(t, h, "bbbbb") // 12 > 10 -> rotate to access.00000001.log
+		writeRotating(t, h, "ccccc") // access.log = "ccccc\n"
+		writeRotating(t, h, "ddddd") // 12 > 10 -> rotate to access.00000002.log
+		writeRotating(t, h, "eeeee") // access.log = "eeeee\n" (still fits)
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Equal(t, "eeeee\n", files["access.log"], "the live file must stay at the fixed prefix.log path")
+		require.Equal(t, "aaaaa\nbbbbb\n", files[idxName("access", 1)])
+		require.Equal(t, "ccccc\nddddd\n", files[idxName("access", 2)])
+		require.NotContains(t, files, idxName("access", 3), "no backup is created for the current live slot")
+	})
+
+	t.Run("resume seeds size from prefix.log; next index is max+1", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// a prior run left a backup at index 5 and a live file near the cap.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 5)), []byte("bck"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "access.log"), bytes.Repeat([]byte("x"), 95), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(100), WithMaxFiles(50), WithStableCurrentName())
+
+		// 95 + "0123456789\n" (11) = 106 > 100 -> rotate. Seeded from the 3-byte backup it
+		// would be 3+11=14 and never rotate: reaching index 6 proves the live seed.
+		writeRotating(t, h, "0123456789")
+		writeRotating(t, h, "next")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files, idxName("access", 6), "next backup index must be highest(5)+1")
+		require.Equal(t, "bck", files[idxName("access", 5)], "the pre-existing backup must be untouched")
+		require.Equal(t, "next\n", files["access.log"], "the fresh live file holds the post-rotation write")
+	})
+
+	t.Run("rotation past a pre-existing index does not clobber", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 1)), []byte("b1\n"), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(5), WithMaxFiles(50), WithStableCurrentName())
+		// resume set index=2; plant a file at that exact slot before the first rotation.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 2)), []byte("PLANTED\n"), defaultFilePermissions))
+
+		writeRotating(t, h, "aaaaa") // 6 > 5 -> rotate; collision guard must skip index 2
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Equal(t, "PLANTED\n", files[idxName("access", 2)], "the pre-existing backup must not be clobbered")
+		require.Equal(t, "aaaaa\n", files[idxName("access", 3)], "rotation must advance to the next free slot")
+	})
+
+	t.Run("small maxFiles over many rotations keeps prefix.log", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(5), WithMaxFiles(2), WithStableCurrentName())
+
+		for i := 0; i < 10; i++ {
+			writeRotating(t, h, "abcde") // 6 > 5 -> rotate on every write
+		}
+		writeRotating(t, h, "z") // fits (2 bytes) -> leaves a live prefix.log present
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files, "access.log", "the live file must survive aggressive pruning")
+		require.Equal(t, "z\n", files["access.log"])
+		require.LessOrEqual(t, len(files), 2, "total files must stay within maxFiles (live + maxFiles-1 backups)")
+	})
+
+	t.Run("off then on adopts legacy backups as backups", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 1)), []byte("legacy1\n"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 2)), []byte("legacy2\n"), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(1000), WithMaxFiles(50), WithStableCurrentName())
+		writeRotating(t, h, "fresh")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Equal(t, "fresh\n", files["access.log"], "the live target must be prefix.log, never a legacy backup")
+		require.Equal(t, "legacy1\n", files[idxName("access", 1)], "legacy backups are adopted untouched")
+		require.Equal(t, "legacy2\n", files[idxName("access", 2)])
+	})
+
+	t.Run("on then off leaves a stale prefix.log in place", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// a prior stable run left prefix.log plus an indexed backup.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "access.log"), []byte("stale-live\n"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("access", 3)), []byte("b3\n"), defaultFilePermissions))
+
+		// indexed mode (no stable option): resume at the highest index and append there.
+		h := RotatingFileHandler(dir, "access", WithMaxFileSize(1000), WithMaxFiles(50))
+		writeRotating(t, h, "indexed-write")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files[idxName("access", 3)], "indexed-write", "indexed mode resumes on the indexed backup")
+		require.Equal(t, "stale-live\n", files["access.log"], "a stale prefix.log survives and must be drained manually")
+	})
+}
+
+func TestRotatingFileHandler_MaxAge(t *testing.T) {
+	t.Run("backdated backups pruned on rotation, fresh kept", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(5), WithMaxFiles(100), WithMaxAge(time.Hour))
+
+		writeRotating(t, h, "aaaaa") // -> app.00000001.log
+		writeRotating(t, h, "bbbbb") // -> app.00000002.log
+		writeRotating(t, h, "ccccc") // -> app.00000003.log (index now 4)
+
+		// backdate the two oldest past the cutoff; leave index 3 fresh.
+		old := time.Now().Add(-2 * time.Hour)
+		require.NoError(t, os.Chtimes(filepath.Join(dir, idxName("app", 1)), old, old))
+		require.NoError(t, os.Chtimes(filepath.Join(dir, idxName("app", 2)), old, old))
+
+		writeRotating(t, h, "ddddd") // fills app.00000004.log, overflows, runs the age prune
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.NotContains(t, files, idxName("app", 1), "over-age backup must be pruned")
+		require.NotContains(t, files, idxName("app", 2), "over-age backup must be pruned")
+		require.Contains(t, files, idxName("app", 3), "under-age backup must be kept")
+		require.Contains(t, files, idxName("app", 4), "the just-rotated fresh backup must be kept")
+	})
+
+	t.Run("negative maxAge is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(5), WithMaxFiles(100), WithMaxAge(-1))
+
+		writeRotating(t, h, "aaaaa") // -> app.00000001.log
+		writeRotating(t, h, "bbbbb") // -> app.00000002.log
+
+		// backdate everything far past any plausible cutoff.
+		old := time.Now().Add(-9000 * time.Hour)
+		require.NoError(t, os.Chtimes(filepath.Join(dir, idxName("app", 1)), old, old))
+		require.NoError(t, os.Chtimes(filepath.Join(dir, idxName("app", 2)), old, old))
+
+		writeRotating(t, h, "ccccc") // triggers another rotation + prune
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files, idxName("app", 1), "WithMaxAge(-1) must disable age pruning")
+		require.Contains(t, files, idxName("app", 2), "WithMaxAge(-1) must disable age pruning")
+	})
+}
+
+// TestPruneRotation exercises the retention core directly: it is deterministic (mtimes are
+// set with os.Chtimes) and isolates the age/count/pair/live-exclusion rules from the write
+// path.
+func TestPruneRotation(t *testing.T) {
+	t.Run("age removes old, keeps fresh", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		touchOld(t, filepath.Join(dir, idxName("app", 1)), "o1\n", 2*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 2)), "f2\n", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 3)), "f3\n", 0)
+
+		cfg := rotatingFileConfig{maxFiles: 100, maxAge: time.Hour}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 4), time.Now()))
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.NotContains(t, files, idxName("app", 1))
+		require.Contains(t, files, idxName("app", 2))
+		require.Contains(t, files, idxName("app", 3))
+	})
+
+	t.Run("live file excluded by name even when old", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		touchOld(t, filepath.Join(dir, idxName("app", 1)), "o1\n", 2*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 2)), "o2\n", 2*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 3)), "live\n", 2*time.Hour) // the current live, old
+
+		cfg := rotatingFileConfig{maxFiles: 100, maxAge: time.Hour}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 3), time.Now()))
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.NotContains(t, files, idxName("app", 1), "over-age backups go")
+		require.NotContains(t, files, idxName("app", 2), "over-age backups go")
+		require.Contains(t, files, idxName("app", 3), "the live file is excluded by name and never pruned")
+	})
+
+	t.Run("count keeps newest maxFiles-1 backups", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		for i := 1; i <= 5; i++ {
+			touchOld(t, filepath.Join(dir, idxName("app", i)), fmt.Sprintf("f%d\n", i), 0)
+		}
+		cfg := rotatingFileConfig{maxFiles: 3, maxAge: 0}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 9), time.Now()))
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.NotContains(t, files, idxName("app", 1))
+		require.NotContains(t, files, idxName("app", 2))
+		require.NotContains(t, files, idxName("app", 3))
+		require.Contains(t, files, idxName("app", 4), "the two newest survive (live is the +1)")
+		require.Contains(t, files, idxName("app", 5))
+	})
+
+	t.Run("age and count union", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		touchOld(t, filepath.Join(dir, idxName("app", 1)), "o1\n", 2*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 2)), "o2\n", 2*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 3)), "f3\n", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 4)), "f4\n", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 5)), "f5\n", 0)
+
+		cfg := rotatingFileConfig{maxFiles: 3, maxAge: time.Hour}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 9), time.Now()))
+
+		files := extractFilesWithGzOrFail(t, dir)
+		// age drops 1,2; count then keeps the newest 2 of {3,4,5}, dropping 3.
+		require.NotContains(t, files, idxName("app", 1))
+		require.NotContains(t, files, idxName("app", 2))
+		require.NotContains(t, files, idxName("app", 3))
+		require.Contains(t, files, idxName("app", 4))
+		require.Contains(t, files, idxName("app", 5))
+	})
+
+	t.Run("gz pair counts as one file", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// index 1 exists as BOTH plaintext and .gz (a crash remnant not yet reconciled).
+		touchOld(t, filepath.Join(dir, idxName("app", 1)), "one\n", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 1)+"."+gzipExtension), "one-gz", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 2)+"."+gzipExtension), "two-gz", 0)
+		touchOld(t, filepath.Join(dir, idxName("app", 3)), "three\n", 0)
+
+		cfg := rotatingFileConfig{maxFiles: 3, maxAge: 0, compress: true}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 9), time.Now()))
+
+		// three backup UNITS {1,2,3}; keep newest two -> unit 1 (both files) removed.
+		require.NoFileExists(t, filepath.Join(dir, idxName("app", 1)))
+		require.NoFileExists(t, filepath.Join(dir, idxName("app", 1)+"."+gzipExtension))
+		require.FileExists(t, filepath.Join(dir, idxName("app", 2)+"."+gzipExtension))
+		require.FileExists(t, filepath.Join(dir, idxName("app", 3)))
+	})
+
+	t.Run("negative maxAge disables age pruning", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		touchOld(t, filepath.Join(dir, idxName("app", 1)), "o1\n", 9000*time.Hour)
+		touchOld(t, filepath.Join(dir, idxName("app", 2)), "f2\n", 0)
+
+		cfg := rotatingFileConfig{maxFiles: 100, maxAge: -1}
+		require.NoError(t, pruneRotation(dir, "app", cfg, idxName("app", 9), time.Now()))
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files, idxName("app", 1), "negative maxAge must not prune by age")
+		require.Contains(t, files, idxName("app", 2))
+	})
+}
+
+func TestRotatingFileHandler_Compress(t *testing.T) {
+	t.Run("rotated backup is a valid gz of the original bytes", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(7), WithMaxFiles(50), WithCompress())
+
+		writeRotating(t, h, "hello") // app.00000001.log = "hello\n" (6)
+		writeRotating(t, h, "world") // 12 > 7 -> rotate; compress index 1
+
+		gzPath := filepath.Join(dir, idxName("app", 1)+"."+gzipExtension)
+		require.FileExists(t, gzPath)
+		require.NoFileExists(t, filepath.Join(dir, idxName("app", 1)), "plaintext must be removed after compression")
+		require.Equal(t, "hello\nworld\n", readGzOrFail(t, gzPath), "the .gz must decompress to the pre-rotation plaintext")
+	})
+
+	t.Run("gz backup permissions are 0640", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(7), WithMaxFiles(50), WithCompress())
+		writeRotating(t, h, "hello")
+		writeRotating(t, h, "world")
+
+		fi, err := os.Stat(filepath.Join(dir, idxName("app", 1)+"."+gzipExtension))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(defaultFilePermissions), fi.Mode().Perm(), "compressed backups must not be world-readable")
+	})
+
+	t.Run("compression preserves the source mtime so age pruning stays honest", func(t *testing.T) {
+		t.Parallel()
+
+		// D4: a genuinely old log compressed today must still age out. If compressFile
+		// dropped its os.Chtimes, the .gz would carry a fresh compression-time mtime and
+		// WithMaxAge would keep it forever; every other test stays green, so this guards
+		// the invariant directly.
+		dir := t.TempDir()
+		src := idxName("app", 1)
+		touchOld(t, filepath.Join(dir, src), "old\n", 72*time.Hour)
+		want, err := os.Stat(filepath.Join(dir, src))
+		require.NoError(t, err)
+
+		require.NoError(t, compressFile(dir, src))
+
+		require.NoFileExists(t, filepath.Join(dir, src), "plaintext removed after compression")
+		fi, err := os.Stat(filepath.Join(dir, src+"."+gzipExtension))
+		require.NoError(t, err)
+		require.WithinDuration(t, want.ModTime(), fi.ModTime(), time.Second,
+			"the .gz must inherit the source mtime, not the compression time")
+	})
+
+	t.Run("prune counts .log and .log.gz, removing oldest regardless of extension", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(5), WithMaxFiles(3), WithCompress())
+
+		for i := 0; i < 6; i++ {
+			writeRotating(t, h, "abcde") // 6 > 5 -> rotate + compress every write
+		}
+		writeRotating(t, h, "z") // fits, leaves a live file
+
+		// live (app.log-indexed) + at most maxFiles-1 compressed backups.
+		gzs, err := filepath.Glob(filepath.Join(dir, "*."+defaultFileExtension+"."+gzipExtension))
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(gzs), 2, "compressed backups must be pruned to maxFiles-1")
+
+		// the surviving backups must be the highest indices (oldest removed).
+		files := extractFilesWithGzOrFail(t, dir)
+		require.NotContains(t, files, idxName("app", 1)+"."+gzipExtension, "the oldest compressed backup must be pruned")
+	})
+
+	t.Run("crash leftover reconciles on next construction", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		// simulate a crash between rename-to-.gz and remove-plaintext: both exist for idx 3.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 3)), []byte("stale-plain\n"), defaultFilePermissions))
+		var gzBuf bytes.Buffer
+		zw := gzip.NewWriter(&gzBuf)
+		_, _ = zw.Write([]byte("authoritative\n"))
+		require.NoError(t, zw.Close())
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 3)+"."+gzipExtension), gzBuf.Bytes(), defaultFilePermissions))
+		// a stray temp from the interrupted compression must also be cleaned.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 3)+"."+gzipExtension+"."+tmpExtension), []byte("junk"), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(1000), WithMaxFiles(50), WithCompress())
+		writeRotating(t, h, "post-recovery")
+
+		require.NoFileExists(t, filepath.Join(dir, idxName("app", 3)), "the stale plaintext must be discarded (the .gz wins)")
+		require.NoFileExists(t, filepath.Join(dir, idxName("app", 3)+"."+gzipExtension+"."+tmpExtension), "stale temp must be cleaned")
+		require.FileExists(t, filepath.Join(dir, idxName("app", 3)+"."+gzipExtension), "the durable .gz must remain")
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Equal(t, "authoritative\n", files[idxName("app", 3)+"."+gzipExtension])
+		require.Contains(t, files, idxName("app", 4), "resume must continue past the .gz-topped index")
+	})
+
+	t.Run("resume from an all-gz backup set starts at highest+1", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		for _, i := range []int{1, 2} {
+			var b bytes.Buffer
+			zw := gzip.NewWriter(&b)
+			_, _ = zw.Write([]byte(fmt.Sprintf("old-%d\n", i)))
+			require.NoError(t, zw.Close())
+			require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", i)+"."+gzipExtension), b.Bytes(), defaultFilePermissions))
+		}
+
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(1000), WithMaxFiles(50), WithCompress())
+		writeRotating(t, h, "resumed")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files[idxName("app", 3)], "resumed", "must resume at highest .gz index + 1, never appending into a .gz")
+	})
+
+	t.Run("fresh start with compress begins genuinely empty", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 1)+"."+gzipExtension), []byte("junk"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 2)), []byte("junk\n"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 2)+"."+gzipExtension+"."+tmpExtension), []byte("junk"), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(1000), WithMaxFiles(50), WithCompress(), WithFreshStart())
+		writeRotating(t, h, "fresh")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Len(t, files, 1, "fresh start must wipe .log, .gz and temp remnants")
+		require.Equal(t, "fresh\n", files[idxName("app", 1)])
+	})
+
+	t.Run("zero-option handler ignores a foreign .log.gz", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "foreign.log.gz"), []byte("not ours"), defaultFilePermissions))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName("app", 1)), []byte("existing\n"), defaultFilePermissions))
+
+		// no compression option: the .gz must not enter globbing/parsing at all.
+		h := RotatingFileHandler(dir, "app", WithMaxFileSize(1000), WithMaxFiles(3))
+		writeRotating(t, h, "more")
+
+		require.FileExists(t, filepath.Join(dir, "foreign.log.gz"), "a foreign .gz must be untouched by a zero-option handler")
+		// use the plaintext-only helper: the foreign .gz holds non-gzip bytes on purpose,
+		// and *.log globbing (like the handler's) never touches it.
+		files, err := extractFilesOrFail(dir)
+		require.NoError(t, err)
+		require.Equal(t, "existing\nmore\n", files[idxName("app", 1)], "resume must ignore the .gz and append to the plaintext")
+	})
+
+	t.Run("resume tolerates glob metacharacters in prefix with compress", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		const prefix = "app[v1]"
+		var b bytes.Buffer
+		zw := gzip.NewWriter(&b)
+		_, _ = zw.Write([]byte("old\n"))
+		require.NoError(t, zw.Close())
+		require.NoError(t, os.WriteFile(filepath.Join(dir, idxName(prefix, 3)+"."+gzipExtension), b.Bytes(), defaultFilePermissions))
+
+		h := RotatingFileHandler(dir, prefix, WithMaxFileSize(1000), WithMaxFiles(50), WithCompress())
+		writeRotating(t, h, "after-restart")
+
+		files := extractFilesWithGzOrFail(t, dir)
+		require.Contains(t, files[idxName(prefix, 4)], "after-restart", "metacharacter prefix must resume past the .gz index")
+	})
+}
+
+// TestRotatingFileHandler_OptionsForRaceCondition drives concurrent writes with the full
+// option set on (stable name + age + compress); the handler's mutex-guarded writer must
+// serialize rotation, rename and synchronous compression with no race and no lost message.
+func TestRotatingFileHandler_OptionsForRaceCondition(t *testing.T) {
+	dir := t.TempDir()
+	h := RotatingFileHandler(dir, "race",
+		WithMaxFileSize(70), WithMaxFiles(10),
+		WithStableCurrentName(), WithMaxAge(time.Hour), WithCompress(),
+	)
+
+	messages := make([]string, 0, 16)
+	for i := 0; i < 16; i++ {
+		messages = append(messages, fmt.Sprintf("%0.3d->>%s", i, uniqueToken()))
+	}
+
+	var mu sync.Mutex
+	var writeErr error
+	var wg sync.WaitGroup
+	for _, m := range messages {
+		wg.Add(1)
+		go func(txt string) {
+			defer wg.Done()
+			if _, e := h.Write([]byte(txt)); e != nil {
+				mu.Lock()
+				writeErr = errors.Join(writeErr, e)
+				mu.Unlock()
+			}
+		}(m)
+	}
+	wg.Wait()
+	require.NoError(t, writeErr)
+
+	all := ""
+	for _, ctx := range extractFilesWithGzOrFail(t, dir) {
+		all += ctx + "\n"
+	}
+	for _, m := range messages {
+		assert.Contains(t, all, m, "every message must survive across rotation, rename and compression")
+	}
+}
+
+// BenchmarkRotatingFileHandler_Write measures the non-rotating hot path with all options
+// off. ReportAllocs guards the byte-identical contract: the options-off write path must
+// not add heap allocations over the plain v1.0.7 handler.
+func BenchmarkRotatingFileHandler_Write(b *testing.B) {
+	dir := b.TempDir()
+	// a huge cap so no write ever rotates: this isolates the append hot path.
+	h := RotatingFileHandler(dir, "bench", WithMaxFileSize(1<<30), WithMaxFiles(10))
+	msg := []byte("benchmark log line payload with a realistic width")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := h.Write(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What

Three opt-in `RotatingFileOption`s on `RotatingFileHandler` so a consumer can drop
`gopkg.in/natefinch/lumberjack.v2` for a single-writer, tail-at-a-stable-path access log:

- **`WithStableCurrentName()`** — the live file stays at a fixed `prefix.log` (backups stay
  indexed `prefix.<8hex>.log`), so external tooling can follow it with `tail -F`.
- **`WithMaxAge(d)`** — prune rotated backups older than `d` by mtime on rotation, on top of
  the count bound; `d <= 0` disables it. The unit is a `time.Duration`.
- **`WithCompress()`** — gzip each rotated backup to `prefix.<8hex>.log.gz` and remove the
  plaintext, synchronously and crash-safely (temp file → fsync → rename → remove; the `.gz`
  preserves the source mtime so age pruning stays honest; a crash-interrupted compression
  self-heals on the next construction, the `.gz` wins).

`NewFileLogger` forwards the age and compression options as `WithMaxFileAge` /
`WithFileCompression` (the bare names are taken); `WithStableCurrentName` is intentionally
not forwarded because `NewFileLogger` timestamps every line.

## Why

The `vpntunnel` access log migrated off lumberjack onto `RotatingFileHandler` and had to
accept three regressions — age retention, compression, and a stable tail-able name. This
closes them additively.

## Guarantees & constraints

- **Byte-identical with zero options** — the existing `RotatingFileHandler` tests pass
  unmodified; a pre-existing foreign `*.log.gz` is ignored unless `WithCompress` is set.
- **Single-writer** — one process must own a `(folder, prefix)` pair (same limitation as
  lumberjack); documented, not defended in code.
- **Compression is synchronous** under the handler mutex — a bounded rotation-time latency
  spike. The async background mill and a `Close()`/shutdown lifecycle are **deferred** (#13).

## Commits

- `feat(handler)` — the options, tests, `NewFileLogger` forwarders, README/godoc, CHANGELOG,
  and a runnable `NewAccessHandler` → stable-name example.
- `fix(handler)` — `FileByFormatHandler` silently dropped its file-close error (unnamed
  returns + a deferred assignment to `err` discarded after the copy); now surfaced, matching
  `RotatingFileHandler`.
- `docs` — correct stale `CLAUDE.md`: handler name (`RotatingFileHandler`, not
  `CyclicOverwritingFilesHandler`), the no-handler default (`TimestampedPrintHandler`), the
  `levels` subpackage, and the `-race` gate needing cgo on this arm64 host.

## Testing

- `gofmt -l .` clean, `go vet ./...` clean.
- `CGO_ENABLED=1 go test -race ./...` green (the race detector needs cgo on this host).
- `CGO_ENABLED=0 go test ./...` green (no-cgo build proof).
- New coverage: a `-race` test driving stable-name + age + compress concurrently;
  compression tests decompress and compare bytes; age tests backdate via `os.Chtimes`; a
  hot-path allocation benchmark (`ReportAllocs`) guards the byte-identical contract;
  cross-restart resume, crash reconciliation, and both stable-name toggle directions.

## Review

The plan was validated by a 10-agent panel (5 architect + 5 reviewer lenses) before any code
was written; the implementation was reviewed across three lenses (correctness/tests,
security/operations, performance/architecture) — approved with zero P0/P1 findings.

## Follow-up (not in this PR)

#13 — async background compression + a `Close()`/shutdown lifecycle, the persistent-fd
optimization, and an explicit `Rotate()` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
